### PR TITLE
Fixes post <title>-tag.

### DIFF
--- a/src/templates/Post.vue
+++ b/src/templates/Post.vue
@@ -13,6 +13,11 @@ import Header from "@/components/Header";
 export default {
   components: {
     Header
+  },
+  metaInfo() {
+    return {
+      title: this.$page.post.title
+    };
   }
 };
 </script>


### PR DESCRIPTION
Hi.

This fixes the `<title>` when on a post.
Before the `<title>` would alwas be `<title>Gridsome Minimal Blog Starter - Gridsome Minimal Blog Starter</title>`, now it will use the actual post title for the first part.

Tested on Gridsome 0.7.23